### PR TITLE
Fix overriding of print to be compatible to stdlib again

### DIFF
--- a/Sha/sha1.cpp
+++ b/Sha/sha1.cpp
@@ -1,6 +1,4 @@
 #include <string.h>
-#include <avr/io.h>
-#include <avr/pgmspace.h>
 #include "sha1.h"
 
 #define SHA1_K0 0x5a827999
@@ -72,9 +70,10 @@ void Sha1Class::addUncounted(uint8_t data) {
   }
 }
 
-void Sha1Class::write(uint8_t data) {
+size_t Sha1Class::write(uint8_t data) {
   ++byteCount;
   addUncounted(data);
+  return 1;
 }
 
 void Sha1Class::pad() {

--- a/Sha/sha1.h
+++ b/Sha/sha1.h
@@ -23,7 +23,7 @@ class Sha1Class : public Print
     void initHmac(const uint8_t* secret, int secretLength);
     uint8_t* result(void);
     uint8_t* resultHmac(void);
-    virtual void write(uint8_t);
+    virtual size_t write(uint8_t);
     using Print::write;
   private:
     void pad();

--- a/Sha/sha256.cpp
+++ b/Sha/sha256.cpp
@@ -1,6 +1,4 @@
 #include <string.h>
-#include <avr/io.h>
-#include <avr/pgmspace.h>
 #include "sha256.h"
 
 uint32_t sha256K[] PROGMEM = {
@@ -87,9 +85,10 @@ void Sha256Class::addUncounted(uint8_t data) {
   }
 }
 
-void Sha256Class::write(uint8_t data) {
+size_t Sha256Class::write(uint8_t data) {
   ++byteCount;
   addUncounted(data);
+  return 1;
 }
 
 void Sha256Class::pad() {

--- a/Sha/sha256.h
+++ b/Sha/sha256.h
@@ -23,7 +23,7 @@ class Sha256Class : public Print
     void initHmac(const uint8_t* secret, int secretLength);
     uint8_t* result(void);
     uint8_t* resultHmac(void);
-    virtual void write(uint8_t);
+    size_t void write(uint8_t);
     using Print::write;
   private:
     void pad();


### PR DESCRIPTION
This should make the code compatible to more recent versions of arduino codebase. But dependencies to avr/* have to be resolved as they seem not to be available with arduino sdk (any more?)